### PR TITLE
Clear 'changed' flags to avoid unintended reconfigure

### DIFF
--- a/lib/libgitlab.py
+++ b/lib/libgitlab.py
@@ -317,7 +317,6 @@ class GitlabHelper:
             )
         )
         fetch.add_source(apt_line, apt_key)
-        fetch.apt_update()
 
     def fetch_gitlab_apt_package(self):
         """Return reference to GitLab package information in the APT cache."""

--- a/reactive/layer_gitlab.py
+++ b/reactive/layer_gitlab.py
@@ -115,6 +115,11 @@ def configure_gitlab(reverseproxy, *args):
     Templates the GitLab Omnibus configuration file, rerunning the OmniBus
     installer to handle actual configuration.
     """
+    # These interfaces don't clear their changed status
+    clear_flag("db.changed")
+    clear_flag("pgsql.database.changed")
+    clear_flag("endpoint.redis.changed")
+
     hookenv.status_set("maintenance", "Configuring GitLab")
     hookenv.log(
         ("Configuring GitLab, then running gitlab-ctl " "reconfigure on changes")


### PR DESCRIPTION
This addresses the major issue from #9 although I believe a more thorough review of how interfaces are being used in this charm is necessary. 

This does two things
 * Clears some of the 'changed' flags that trigger a reconfigure because the interfaces don't do that the charm using them has to
 * Removes a double 'apt_update' that happens during the reconfigure

This passes tests and update_status now completes reasonably quickly. I have found that it does still have several wrong flags set I've only addressed the three flags that trigger reconfigure with this merge. All three of these interfaces probably need a better set of hooks to deal with their changed status and call the gitlab_configure function when necessary to fully fix the interfaces.

As an example, you'll see update status still has some of the relations/interfaces running through unnecessary configuration checks/changes because they believe things have changed which haven't. This is the full list of interface flags that still exist and need to be cleared by this charm after it's dealt with them so the interfaces stop trying to reconfigure when nothing is changing. Clearly none of these 'changed' values actually changed just by running update-status but the gitlab-charm isn't clearing them from when they are originally set during install.

> tracer: set flag endpoint.db.changed
> tracer: set flag endpoint.db.changed.database
> tracer: set flag endpoint.db.changed.egress-subnets
> tracer: set flag endpoint.db.changed.host
> tracer: set flag endpoint.db.changed.ingress-address
> tracer: set flag endpoint.db.changed.password
> tracer: set flag endpoint.db.changed.private-address
> tracer: set flag endpoint.db.changed.slave
> tracer: set flag endpoint.db.changed.user
> tracer: set flag endpoint.db.departed
> tracer: set flag endpoint.pgsql.changed.allowed-subnets
> tracer: set flag endpoint.pgsql.changed.allowed-units
> tracer: set flag endpoint.pgsql.changed.database
> tracer: set flag endpoint.pgsql.changed.egress-subnets
> tracer: set flag endpoint.pgsql.changed.host
> tracer: set flag endpoint.pgsql.changed.ingress-address
> tracer: set flag endpoint.pgsql.changed.master
> tracer: set flag endpoint.pgsql.changed.password
> tracer: set flag endpoint.pgsql.changed.port
> tracer: set flag endpoint.pgsql.changed.private-address
> tracer: set flag endpoint.pgsql.changed.state
> tracer: set flag endpoint.pgsql.changed.user
> tracer: set flag endpoint.pgsql.changed.version
> tracer: set flag endpoint.pgsql.joined
> tracer: set flag endpoint.redis.available
> tracer: set flag endpoint.redis.changed.egress-subnets
> tracer: set flag endpoint.redis.changed.host
> tracer: set flag endpoint.redis.changed.ingress-address
> tracer: set flag endpoint.redis.changed.port
> tracer: set flag endpoint.redis.changed.private-address
> tracer: set flag endpoint.redis.joined
> tracer: set flag pgsql.connected
> tracer: set flag pgsql.database.available
> tracer: set flag pgsql.master.available
> tracer: set flag pgsql.master.changed
> tracer: set flag pgsql.standbys.changed