### PR TITLE
Add the runner endpoint for registration

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -6,6 +6,7 @@ includes:
   - interface:pgsql
   - interface:mysql
   - interface:redis
+  - interface:gitlab-ci
 ignore:
   - report
   - tests

--- a/reactive/layer_gitlab.py
+++ b/reactive/layer_gitlab.py
@@ -213,7 +213,7 @@ def get_runner_token():
 @when_all("endpoint.runner.joined", "gitlab.configured")
 @when_not("runner.published")
 def publish_runner_config():
-    """ Publish the configuration for a runner to register """
+    """Publish the configuration for a runner to register."""
     endpoint = endpoint_from_flag("endpoint.runner.joined")
     server_uri = "http://{}".format(socket.getfqdn())
     server_token = get_runner_token()
@@ -227,5 +227,5 @@ def publish_runner_config():
 
 @when("endpoint.runner.departed")
 def handle_runner_departed():
-    """Handle relations departed"""
+    """Handle relations departed."""
     clear_flag("runner.published")

--- a/reactive/layer_gitlab.py
+++ b/reactive/layer_gitlab.py
@@ -1,6 +1,6 @@
 """Provides the main reactive layer for the GitLab charm."""
 
-import socket
+# import socket
 import subprocess
 
 from charmhelpers.core import hookenv
@@ -215,7 +215,7 @@ def get_runner_token():
 def publish_runner_config():
     """Publish the configuration for a runner to register."""
     endpoint = endpoint_from_flag("endpoint.runner.joined")
-    server_uri = "http://{}".format(socket.getfqdn())
+    server_uri = gitlab.get_external_uri()
     server_token = get_runner_token()
     hookenv.log(
         "Publishing runner config uri/token: {}/{}".format(server_uri, server_token),

--- a/reactive/layer_gitlab.py
+++ b/reactive/layer_gitlab.py
@@ -202,12 +202,15 @@ def configure_proxy():
 
 def get_runner_token():
     """Get the runner token for registering a runner."""
-    cmd = (
-        "gitlab-rails runner -e production "
-        "'puts Gitlab::CurrentSettings.current_application_settings.runners_registration_token'"
-    )
-    result = subprocess.check_output(cmd, shell=True)
-    return result.decode("utf-8").rstrip("\n")
+    cmd = [
+        "/usr/bin/gitlab-rails",
+        "runner",
+        "-e",
+        "production",
+        "STDOUT.write Gitlab::CurrentSettings.current_application_settings.runners_registration_token" 
+    ]
+    token = subprocess.check_output(cmd)
+    return token.decode("utf-8")
 
 
 @when_all("endpoint.runner.joined", "gitlab.configured")


### PR DESCRIPTION
This adds the ci-relation named 'runner' to allow the runner to register via relation. There is no functional test for this on the Gitlab charm, and I've added that testing to the runner instead. This branch has to land before the runner will pass testing since Gitlab is pulled from the charm store during the runner functional testing.