### PR TITLE
Write smtp_tls as boolean instead of string

### DIFF
--- a/lib/libgitlab.py
+++ b/lib/libgitlab.py
@@ -494,7 +494,7 @@ class GitlabHelper:
                     "smtp_password": self.charm_config.get("smtp_password"),
                     "smtp_domain": self.get_smtp_domain(),
                     "smtp_authentication": self.charm_config.get("smtp_authentication"),
-                    "smtp_tls": self.charm_config.get("smtp_tls"),
+                    "smtp_tls": str(self.charm_config.get("smtp_tls")).lower(),
                     "url": self.get_external_uri(),
                 },
             )
@@ -521,7 +521,7 @@ class GitlabHelper:
                     "smtp_password": self.charm_config.get("smtp_password"),
                     "smtp_domain": self.get_smtp_domain(),
                     "smtp_authentication": self.charm_config.get("smtp_authentication"),
-                    "smtp_tls": self.charm_config.get("smtp_tls"),
+                    "smtp_tls": str(self.charm_config.get("smtp_tls")).lower(),
                     "url": self.get_external_uri(),
                 },
             )
@@ -548,7 +548,7 @@ class GitlabHelper:
                     "smtp_password": self.charm_config.get("smtp_password"),
                     "smtp_domain": self.get_smtp_domain(),
                     "smtp_authentication": self.charm_config.get("smtp_authentication"),
-                    "smtp_tls": self.charm_config.get("smtp_tls"),
+                    "smtp_tls": str(self.charm_config.get("smtp_tls")).lower(),
                     "url": self.get_external_uri(),
                 },
             )

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -31,7 +31,7 @@ gitlab_rails['smtp_password'] = "{{ smtp_password }}"
 gitlab_rails['smtp_domain'] = "{{ smtp_domain }}"
 gitlab_rails['smtp_authentication'] = "{{ smtp_authentication }}"
 gitlab_rails['smtp_enable_starttls_auto'] = true
-gitlab_rails['smtp_tls'] = "{{ smtp_tls }}"
+gitlab_rails['smtp_tls'] = {{ smtp_tls }}
 {% endif %}
 
 


### PR DESCRIPTION
Currently the charm renders smtp_tls in the template as a string, when in fact it should be a boolean. This PR fixes #20 by no longer quoting it and downcasing it.