### PR TITLE
Add support for gitlab email settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,3 +63,15 @@ options:
     type: boolean
     default: false
     description: "Set this to true to enable TLS when connecting to the configured external SMTP server."
+  email_from:
+    type: string
+    default: ""
+    description: "Email address from which gitlab will send email. Defaults to gitlab@external_url."
+  email_display_name:
+    type: string
+    default: ""
+    description: "Display name for emails from gitlab. Defaults to GitLab"
+  email_reply_to:
+    type: string
+    default: ""
+    description: "Email address to be used as reply-to for emails from gitlab. Defaults to noreply@external_url."

--- a/lib/libgitlab.py
+++ b/lib/libgitlab.py
@@ -495,6 +495,9 @@ class GitlabHelper:
                     "smtp_domain": self.get_smtp_domain(),
                     "smtp_authentication": self.charm_config.get("smtp_authentication"),
                     "smtp_tls": str(self.charm_config.get("smtp_tls")).lower(),
+                    "email_from": self.charm_config.get("email_from"),
+                    "email_display_name": self.charm_config.get("email_display_name"),
+                    "email_reply_to": self.charm_config.get("email_reply_to"),
                     "url": self.get_external_uri(),
                 },
             )
@@ -522,6 +525,9 @@ class GitlabHelper:
                     "smtp_domain": self.get_smtp_domain(),
                     "smtp_authentication": self.charm_config.get("smtp_authentication"),
                     "smtp_tls": str(self.charm_config.get("smtp_tls")).lower(),
+                    "email_from": self.charm_config.get("email_from"),
+                    "email_display_name": self.charm_config.get("email_display_name"),
+                    "email_reply_to": self.charm_config.get("email_reply_to"),
                     "url": self.get_external_uri(),
                 },
             )
@@ -549,6 +555,9 @@ class GitlabHelper:
                     "smtp_domain": self.get_smtp_domain(),
                     "smtp_authentication": self.charm_config.get("smtp_authentication"),
                     "smtp_tls": str(self.charm_config.get("smtp_tls")).lower(),
+                    "email_from": self.charm_config.get("email_from"),
+                    "email_display_name": self.charm_config.get("email_display_name"),
+                    "email_reply_to": self.charm_config.get("email_reply_to"),
                     "url": self.get_external_uri(),
                 },
             )

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -34,6 +34,16 @@ gitlab_rails['smtp_enable_starttls_auto'] = true
 gitlab_rails['smtp_tls'] = {{ smtp_tls }}
 {% endif %}
 
+##! Email settings
+{% if email_from %}
+gitlab_rails['gitlab_email_from'] = '{{ email_from }}'
+{% endif %}
+{% if email_display_name %}
+gitlab_rails['gitlab_email_display_name'] = '{{ email_display_name }}'
+{% endif %}
+{% if email_reply_to %}
+gitlab_rails['gitlab_email_reply_to'] = '{{ email_reply_to }}'
+{% endif %}
 
 ##! Redis settings
 #### Redis TCP connection

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -505,6 +505,41 @@ def test_render_smtp_settings_with_login(database_type, libgitlab):
     assert "gitlab_rails['smtp_tls'] = true" in config_lines
 
 
+@pytest.mark.parametrize("database_type", ("pgsql", "mysql", "legacy"))
+@pytest.mark.parametrize("email_from", ("test@example.com", ""))
+@pytest.mark.parametrize("email_display_name", ("name", ""))
+@pytest.mark.parametrize("email_reply_to", ("noreply@example.com", ""))
+def test_render_email_settings(database_type, email_from, email_display_name, email_reply_to, libgitlab):
+    """Test render of configuration when email settings are configured."""
+    libgitlab.charm_config["email_from"] = email_from
+    libgitlab.charm_config["email_display_name"] = email_display_name
+    libgitlab.charm_config["email_reply_to"] = email_reply_to
+
+    config_lines = _rendered_config(database_type, libgitlab)
+
+    # Assert that email options were properly configured in gitlab config
+    if email_from:
+        assert "gitlab_rails['gitlab_email_from'] = '{}'".format(email_from) in config_lines
+    else:
+        assert not any(
+            (l.startswith("gitlab_rails['gitlab_email_from']") for l in config_lines)
+        )
+
+    if email_display_name:
+        assert "gitlab_rails['gitlab_email_display_name'] = '{}'".format(email_display_name) in config_lines
+    else:
+        assert not any(
+            (l.startswith("gitlab_rails['gitlab_email_display_name']") for l in config_lines)
+        )
+
+    if email_reply_to:
+        assert "gitlab_rails['gitlab_email_reply_to'] = '{}'".format(email_reply_to) in config_lines
+    else:
+        assert not any(
+            (l.startswith("gitlab_rails['gitlab_email_reply_to']") for l in config_lines)
+        )
+
+
 def _rendered_config(database_type, libgitlab):
     _configure_database(database_type, libgitlab)
 


### PR DESCRIPTION
This PR resolves #19 by adding configuration support for gitlab's `gitlab_email_from`, `gitlab_email_display_name`, and `gitlab_email_reply_to` settings.