### PR TITLE
Add support for changing internal SSH port

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,11 +19,11 @@ options:
     type: int
     default: 80
     description: "The HTTP port the GitLab backend will listen for connections on. It is recommended to relate this charm to a reverse proxy, rather than customising this value"
-  ssh_port:
+  proxy_ssh_port:
     type: int
     default: 222
-    description: "The external TCP port over which SSH-based git clone operations will be available, when GitLab is related to an external load balancer via the reverseproxy relation. Without a reverseproxy relation, ssh_port_internal is used."
-  ssh_port_internal:
+    description: "The external TCP port over which SSH-based git clone operations will be available, when GitLab is related to an external load balancer via the reverseproxy relation. Without a reverseproxy relation, ssh_port is used."
+  ssh_port:
     type: int
     default: 22
     description: "The internal TCP port on which SSH-based git clone operations will be available. Port 22 by default."

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,11 @@ options:
   ssh_port:
     type: int
     default: 222
-    description: "The external TCP port over which SSH-based git clone operations will be available, when GitLab is related to an external load balancer via the reverseproxy relation. Without a reverseproxy relation, the system sshd is used on port 22."
+    description: "The external TCP port over which SSH-based git clone operations will be available, when GitLab is related to an external load balancer via the reverseproxy relation. Without a reverseproxy relation, ssh_port_internal is used."
+  ssh_port_internal:
+    type: int
+    default: 22
+    description: "The internal TCP port on which SSH-based git clone operations will be available. Port 22 by default."
   package_name:
     type: string
     default: "gitlab-ce"

--- a/lib/libgitlab.py
+++ b/lib/libgitlab.py
@@ -76,8 +76,8 @@ class GitlabHelper:
     def get_sshport(self):
         """Return the host used when configuring SSH access to GitLab."""
         if _get_flag_value("reverseproxy.configured"):
-            return self.charm_config["ssh_port"]
-        return self.charm_config["ssh_port_internal"]
+            return self.charm_config["proxy_ssh_port"]
+        return self.charm_config["ssh_port"]
 
     def get_smtp_enabled(self):
         """Return True if all configuration is in place for external SMTP usage."""
@@ -117,9 +117,9 @@ class GitlabHelper:
             },
             {
                 "mode": "tcp",
-                "external_port": self.charm_config["ssh_port"],
+                "external_port": self.charm_config["proxy_ssh_port"],
                 "internal_host": internal_host,
-                "internal_port": self.charm_config["ssh_port_internal"],
+                "internal_port": self.charm_config["ssh_port"],
             },
         ]
         proxy.configure(proxy_config)
@@ -574,7 +574,7 @@ class GitlabHelper:
 
     def open_ports(self):
         """Open ports based on configuration."""
-        ports = ["80", str(self.charm_config["ssh_port_internal"])]
+        ports = ["80", str(self.charm_config["ssh_port"])]
         opened_ports = hookenv.opened_ports()
         for open_port in opened_ports:
             port_no = open_port.split("/")[0]

--- a/lib/libgitlab.py
+++ b/lib/libgitlab.py
@@ -77,7 +77,7 @@ class GitlabHelper:
         """Return the host used when configuring SSH access to GitLab."""
         if _get_flag_value("reverseproxy.configured"):
             return self.charm_config["ssh_port"]
-        return "22"
+        return self.charm_config["ssh_port_internal"]
 
     def get_smtp_enabled(self):
         """Return True if all configuration is in place for external SMTP usage."""
@@ -119,7 +119,7 @@ class GitlabHelper:
                 "mode": "tcp",
                 "external_port": self.charm_config["ssh_port"],
                 "internal_host": internal_host,
-                "internal_port": 22,
+                "internal_port": self.charm_config["ssh_port_internal"],
             },
         ]
         proxy.configure(proxy_config)
@@ -574,7 +574,7 @@ class GitlabHelper:
 
     def open_ports(self):
         """Open ports based on configuration."""
-        ports = ["80", "22"]
+        ports = ["80", str(self.charm_config["ssh_port_internal"])]
         opened_ports = hookenv.opened_ports()
         for open_port in opened_ports:
             port_no = open_port.split("/")[0]

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -60,12 +60,12 @@ def test_get_sshport(libgitlab, mock_gitlab_get_flag_value):
     """Test get_sshport."""
     result = libgitlab.get_sshport()
     assert result == 22
-    libgitlab.charm_config["ssh_port_internal"] = 922
-    result = libgitlab.get_sshport()
-    assert result == libgitlab.charm_config["ssh_port_internal"]
-    mock_gitlab_get_flag_value.return_value = True
+    libgitlab.charm_config["ssh_port"] = 922
     result = libgitlab.get_sshport()
     assert result == libgitlab.charm_config["ssh_port"]
+    mock_gitlab_get_flag_value.return_value = True
+    result = libgitlab.get_sshport()
+    assert result == libgitlab.charm_config["proxy_ssh_port"]
 
 
 def test_get_smtp_enabled(libgitlab, mock_gitlab_get_flag_value):
@@ -93,14 +93,14 @@ def test_ports(libgitlab, mock_open_port, mock_close_port, mock_opened_ports):
 
 
 @pytest.mark.parametrize("external_url", ("https://mock.example.com", ""))
-@pytest.mark.parametrize("ssh_port", (222, 2222))
-@pytest.mark.parametrize("ssh_port_internal", (22, 922))
-def test_configure_proxy(libgitlab, external_url, ssh_port, ssh_port_internal):
+@pytest.mark.parametrize("proxy_ssh_port", (222, 2222))
+@pytest.mark.parametrize("ssh_port", (22, 922))
+def test_configure_proxy(libgitlab, external_url, proxy_ssh_port, ssh_port):
     """Test configure_proxy."""
     mock_proxy = mock.Mock()
     libgitlab.charm_config["external_url"] = external_url
+    libgitlab.charm_config["proxy_ssh_port"] = proxy_ssh_port
     libgitlab.charm_config["ssh_port"] = ssh_port
-    libgitlab.charm_config["ssh_port_internal"] = ssh_port_internal
     libgitlab.configure_proxy(mock_proxy)
 
     expected_external_http_port = 80
@@ -119,9 +119,9 @@ def test_configure_proxy(libgitlab, external_url, ssh_port, ssh_port_internal):
             },
             {
                 "mode": "tcp",
-                "external_port": ssh_port,
+                "external_port": proxy_ssh_port,
                 "internal_host": "mock.example.com",
-                "internal_port": ssh_port_internal,
+                "internal_port": ssh_port,
             },
         ]
     )


### PR DESCRIPTION
Currently the charm only supports using port 22 for the internal SSH port. However, there are various reasons why the internal SSH port may need to be something other than the default 22. This PR resolves #26 by adding the `ssh_port_internal` configuration parameter to support these use-cases.